### PR TITLE
Disable release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,10 +1,10 @@
 name: release-please
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
+on: workflow_dispatch
+  # push:
+  #   branches:
+  #     - main
+  # pull_request:
 
 jobs:
   release-please:


### PR DESCRIPTION
Disable the original `node-gyp` release workflow 