### PR TITLE
Fix isVisible() so that all log levels won't get printed all the time

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -97,7 +97,11 @@ class Logger {
   }
 
   isVisible (level) {
-    return (this.level && this.level.index <= (this.#levels.get(level) && this.#levels.get(level).index) || -1)
+    if (!this.level || !this.#levels.get(level)) {
+      return false
+    }
+    
+    return this.level.index <= this.#levels.get(level).index
   }
 
   _onLog (...args) {


### PR DESCRIPTION
Log level `silly` is getting output which outputs all env vars which is a bit dodgy - it will eventually leak secrets if users aren't cautious. 

`(this.level && this.level.index <= (this.#levels.get(level) && this.#levels.get(level).index) || -1)` simplifies to `(a && b || -1)` which is always truthy.

Furthermore I think the || -1 would have turned log lines of index 0's index into -1 so they would never match once the parenthesis is fixed. (Why not use the ?? operator?)

I think this is just easier to reason about and to get right if you check for null/undefined up front where you expect objects and then early return. Then you also can't turn 0 into -1 accidentally and it reads much more easily.


